### PR TITLE
fix leak issue.

### DIFF
--- a/BarrageRenderer/BarrageEngine/BarrageClock.m
+++ b/BarrageRenderer/BarrageEngine/BarrageClock.m
@@ -50,14 +50,13 @@
 {
     if (self = [super init]) {
         _block = block;
-        [self reset];
     }
     return self;
 }
 
 - (void)reset
 {
-     _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(update)];
+    _displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(update)];
     _speed = 1.0f;
     _pausedSpeed = _speed;
     self.launched = NO;
@@ -71,11 +70,13 @@
 
 - (void)start
 {
+    if (!_displayLink) {
+        [self reset];
+    }
+    
     if (self.launched) {
         _speed = _pausedSpeed;
-    }
-    else
-    {
+    } else {
         _previousDate = CACurrentMediaTime();
         [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
         self.launched = YES;
@@ -100,7 +101,7 @@
 - (void)stop
 {
     [_displayLink invalidate];
-    [self reset];
+    _displayLink = nil;
 }
 
 /// 更新逻辑时间系统


### PR DESCRIPTION
#21 fix this issue.
Maybe I need show how the leak issue occurred.
`     
_displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(update)];		
`
CADisplayLink would keep a strong reference after we added 'self' as its target.And it only removed 'self' target until we called 
`
[_displayLink invalidate];
`
That caused this issue.Let's check out the old codes.The method 'reset' init a 'CADisplayLink' instance and add 'self' as its target.The method 'stop' invalidate the 'link' instance but called 'reset' method which init a new 'link' instance again.