### PR TITLE
Swift与OC互调低解决问题

### DIFF
--- a/BarrageRenderer/BarrageEngine/BarrageDescriptor.h
+++ b/BarrageRenderer/BarrageEngine/BarrageDescriptor.h
@@ -41,4 +41,7 @@
 /// 弹幕标识符,用于防止弹幕重复,内部一次性生成
 @property(nonatomic,strong,readonly)NSString * identifier;
 
+/// 弹幕点击事件回调
+- (void)clickAction:(BarrageClickAction)clickAction;
+
 @end

--- a/BarrageRenderer/BarrageEngine/BarrageDescriptor.m
+++ b/BarrageRenderer/BarrageEngine/BarrageDescriptor.m
@@ -62,4 +62,9 @@
     return copy;
 }
 
+- (void)clickAction:(BarrageClickAction)clickAction{
+    
+    self.params[@"clickAction"] = clickAction;
+    
+}
 @end


### PR DESCRIPTION
OC的Block不能与Swift的闭包直接通过属性传值,添加如下代码后
OC调用点击事件:
    descriptor.params[@"clickAction"] = ^(NSDictionary *params){
       //TODO
    };
Swift调用点击事件:
      descriptor.clickAction { (params) in
     //TODO
     }
已测试可行
 
